### PR TITLE
Revert "Feature/fix symfony4 acl on var shared subfolders (#2933)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Changelog
 
 
-## master
-[v6.8.0...master](https://github.com/deployphp/deployer/compare/v6.8.0...master)
-
-### Fixed
-- Symfony 4 recipe log and session folders ACL check [#2932]
-
-
 ## v6.8.0
 [v6.7.3...v6.8.0](https://github.com/deployphp/deployer/compare/v6.7.3...v6.8.0)
 
@@ -572,7 +565,6 @@
 - Fixed remove of shared dir on first deploy
 
 
-[#2932]: https://github.com/deployphp/deployer/issues/2932
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990
 [#1989]: https://github.com/deployphp/deployer/issues/1989

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
 set('shared_files', ['.env.local.php', '.env.local']);
-set('writable_dirs', ['var/cache', 'var/log', 'var/sessions']);
+set('writable_dirs', ['var']);
 set('migrations_config', '');
 
 set('bin/console', function () {


### PR DESCRIPTION
This reverts commit 28534235ede6407ad2d59067a1f326f3d430d936.

This commit wasn't released, and it creates some issues with our code. So the decision is to revert this commit as we're just forking official repository.